### PR TITLE
Enclose filename in inverted comma

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -22,7 +22,7 @@ function activate(context) {
     param.push(`fix '${vscode.window.activeTextEditor.document.fileName}' --using-cache=no`)
 
     if (config.configFile) {
-      param.push(`--config=${config.configFile}`)
+      param.push(`--config='${config.configFile}'`)
     }
 
     if (config.pathMode) {

--- a/extension.js
+++ b/extension.js
@@ -19,7 +19,7 @@ function activate(context) {
       param.push(config.executable)
     }
 
-    param.push(`fix ${vscode.window.activeTextEditor.document.fileName} --using-cache=no`)
+    param.push(`fix '${vscode.window.activeTextEditor.document.fileName}' --using-cache=no`)
 
     if (config.configFile) {
       param.push(`--config=${config.configFile}`)


### PR DESCRIPTION
Fixing Issue #4.

I've tried this and it seems to work with folders that have spaces in them.