### PR TITLE
Single quotation marks don't work on Windows 10

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -19,10 +19,10 @@ function activate(context) {
       param.push(config.executable)
     }
 
-    param.push(`fix '${vscode.window.activeTextEditor.document.fileName}' --using-cache=no`)
+    param.push(`fix ${vscode.window.activeTextEditor.document.fileName} --using-cache=no`)
 
     if (config.configFile) {
-      param.push(`--config='${config.configFile}'`)
+      param.push(`--config=${config.configFile}`)
     }
 
     if (config.pathMode) {


### PR DESCRIPTION
Single quotation marks causing ERR Command failed because it doesn't find the file to fix and the configuration file